### PR TITLE
Avoid playback error on platforms where char is unsigned

### DIFF
--- a/hxcmod.c
+++ b/hxcmod.c
@@ -227,7 +227,7 @@ static void worknote( note * nptr, channel * cptr,char t,modcontext * mod )
 
 		if( period || sample )
 		{
-			cptr->sampdata =(char *) mod->sampledata[cptr->sampnum];
+			cptr->sampdata = mod->sampledata[cptr->sampnum];
 			cptr->length = mod->song.samples[cptr->sampnum].length;
 			cptr->reppnt = mod->song.samples[cptr->sampnum].reppnt;
 			cptr->replen = mod->song.samples[cptr->sampnum].replen;
@@ -978,7 +978,7 @@ int hxcmod_load( modcontext * modctx, void * mod_data, int mod_data_size )
 
 				if (sptr->length == 0) continue;
 
-				modctx->sampledata[i] = (char*)modmemory;
+				modctx->sampledata[i] = (mchar*)modmemory;
 				modmemory += sptr->length;
 
 				if (sptr->replen + sptr->reppnt > sptr->length)

--- a/hxcmod.h
+++ b/hxcmod.h
@@ -22,6 +22,7 @@
 
 // Basic type
 typedef unsigned char	muchar;
+typedef signed   char   mchar;
 typedef unsigned short	muint;
 typedef          short	mint;
 typedef unsigned long	mulong;
@@ -67,7 +68,7 @@ typedef struct {
 // HxCMod Internal structures
 //
 typedef struct {
-	char *  sampdata;
+	mchar * sampdata;
 	muint   sampnum;
 	muint   length;
 	muint   reppnt;
@@ -104,7 +105,7 @@ typedef struct {
 
 typedef struct {
 	module  song;
-	char *  sampledata[31];
+	mchar * sampledata[31];
 	note *  patterndata[128];
 
 	mulong  playrate;


### PR DESCRIPTION
Sample data is 8-bit signed. If it's being accessed by a char * and char
is unsigned, wrong samples are calculated.

This patch introduces a mchar type and uses it to store reference to
sample data.

I had problem with playback on the following embedded systems:
- esp32
- Atmel SAMV71 with default Makefile
- STM32L053 with Makefile from STM32CubeMX

Thanks for providing the mod player in the first place. We're using it for A2DP Audio Source Demo of our Bluetooth stack: http://btstack.org
