### PR TITLE
Fix arpeggio (0xy) effect

### DIFF
--- a/hxcmod.c
+++ b/hxcmod.c
@@ -12,7 +12,7 @@
 // File : hxcmod.c
 // Contains: a tiny mod player
 //
-// Written by: Jean-François DEL NERO
+// Written by: Jean-FranÃ§ois DEL NERO
 //
 // You are free to do what you want with this code.
 // A credit is always appreciated if you include it into your prod :)
@@ -414,12 +414,12 @@ static void memclear( void * dest, unsigned char value, unsigned long size )
 	}
 }
 
-static int getnote( modcontext * mod, unsigned short period )
+static int getnote( modcontext * mod, unsigned short period, unsigned char finetune )
 {
 	int i;
 	const short * ptr;
 
-	ptr = periodtable_finetune_ptr[0];
+	ptr = periodtable_finetune_ptr[finetune&15];
 
 	for(i = 0; i < MAXNOTES; i++)
 	{
@@ -570,7 +570,7 @@ static void worknote( note * nptr, channel * cptr,char t,modcontext * mod )
 			if( cptr->finetune )
 			{
 				period_table_ptr = periodtable_finetune_ptr[cptr->finetune&0xF];
-				period = period_table_ptr[getnote(mod,period)];
+				period = period_table_ptr[getnote(mod,period,0)];
 			}
 
 			cptr->period = period;
@@ -611,7 +611,7 @@ static void worknote( note * nptr, channel * cptr,char t,modcontext * mod )
 
 				cptr->ArpIndex = 0;
 
-				curnote = getnote(mod,cptr->period);
+				curnote = getnote(mod,cptr->period,cptr->finetune);
 
 				cptr->Arpperiods[0] = cptr->period;
 
@@ -921,7 +921,7 @@ static void worknote( note * nptr, channel * cptr,char t,modcontext * mod )
 					if( period )
 					{
 						period_table_ptr = periodtable_finetune_ptr[cptr->finetune&0xF];
-						period = period_table_ptr[getnote(mod,period)];
+						period = period_table_ptr[getnote(mod,period,cptr->finetune)];
 						cptr->period = period;
 					}
 
@@ -1134,11 +1134,11 @@ static void workeffect( modcontext * modctx, note * nptr, channel * cptr )
 
 			if( cptr->parameffect )
 			{
-				cptr->decalperiod = cptr->period - cptr->Arpperiods[cptr->ArpIndex];
-
 				cptr->ArpIndex++;
 				if( cptr->ArpIndex>2 )
 					cptr->ArpIndex = 0;
+
+				cptr->decalperiod = cptr->period - cptr->Arpperiods[cptr->ArpIndex];
 			}
 		break;
 

--- a/hxcmod.c
+++ b/hxcmod.c
@@ -419,7 +419,7 @@ static int getnote( modcontext * mod, unsigned short period, unsigned char finet
 	int i;
 	const short * ptr;
 
-	ptr = periodtable_finetune_ptr[finetune&15];
+	ptr = periodtable_finetune_ptr[finetune&0xF];
 
 	for(i = 0; i < MAXNOTES; i++)
 	{
@@ -917,14 +917,14 @@ static void worknote( note * nptr, channel * cptr,char t,modcontext * mod )
 					more info on finetune values).
 					*/
 
-					cptr->finetune = effect_param_l;
-
 					if( period )
 					{
-						period_table_ptr = periodtable_finetune_ptr[cptr->finetune&0xF];
+						period_table_ptr = periodtable_finetune_ptr[effect_param_l&0xF];
 						period = period_table_ptr[getnote(mod,period,cptr->finetune)];
 						cptr->period = period;
 					}
+
+					cptr->finetune = effect_param_l;
 
 				break;
 

--- a/hxcmod.c
+++ b/hxcmod.c
@@ -564,7 +564,6 @@ static void worknote( note * nptr, channel * cptr,char t,modcontext * mod )
 				cptr->samppos = 0;
 		}
 
-		cptr->decalperiod = 0;
 		if( period )
 		{
 			if( cptr->finetune )
@@ -576,6 +575,8 @@ static void worknote( note * nptr, channel * cptr,char t,modcontext * mod )
 			cptr->period = period;
 		}
 	}
+
+	cptr->decalperiod = 0;
 
 	cptr->effect = 0;
 	cptr->parameffect = 0;


### PR DESCRIPTION
Arpeggio pitch is calculated incorrectly if the sample has a non-zero finetune. Additionally, it also plays one tick late (as in, it plays as 0-0-x-y-0-x instead of 0-x-y-0-x-y). This patch fixes both of these issues.